### PR TITLE
feat: auth con api

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://digitalmoney.ctd.academy

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -80,7 +80,7 @@ const Login = () => {
     setIsSubmiting(true);
     login(email, password)
       .then((response) => {
-        setToken(response.accessToken);
+        setToken(response.token);
         setTimeout(() => {
           setIsSubmiting(false);
           setIsAuthenticated(true);

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -44,7 +44,7 @@ interface RegisterInputs {
   name: string;
   lastName: string;
   phone: string;
-  dni: string;
+  dni: number;
   email: string;
   password: string;
   passwordRepeated: string;
@@ -111,12 +111,13 @@ const Register = () => {
     email,
   }) => {
     setIsSubmiting(true);
+    const parsedDni = parseInt(String(dni));
     createAnUser({
       firstName: name,
       lastName,
       password,
       phone,
-      dni,
+      dni: parsedDni,
       email,
     })
       .then((response) => {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,7 +4,7 @@ export interface User {
   email: string;
   password: string;
   phone?: string;
-  dni?: string;
+  dni?: number;
   id?: string;
 }
 

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -16,6 +16,7 @@ const myRequest = (endpoint: string, method: string, token?: string) =>
   new Request(endpoint, myInit(method, token));
 
 const baseUrl = 'http://localhost:3500';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
 const rejectPromise = (response?: Response): Promise<Response> =>
   Promise.reject({
@@ -25,7 +26,7 @@ const rejectPromise = (response?: Response): Promise<Response> =>
   });
 
 export const login = (email: string, password: string) => {
-  return fetch(myRequest(`${baseUrl}/login`, 'POST'), {
+  return fetch(myRequest(`${API_BASE_URL}/api/login`, 'POST'), {
     body: JSON.stringify({ email, password }),
   })
     .then((response) => {
@@ -41,7 +42,7 @@ export const login = (email: string, password: string) => {
 };
 
 export const createAnUser = (user: User) => {
-  return fetch(myRequest(`${baseUrl}/register`, 'POST'), {
+  return fetch(myRequest(`${API_BASE_URL}/api/users`, 'POST'), {
     body: JSON.stringify(user),
   })
     .then((response) => {


### PR DESCRIPTION
Meti los endpoints de crear usuario y login de la API. Hubo que hacer dos modificaciones:

- La escritura del token en el localStorage, cambio el nombre de la prop del objeto que se escribe por la respuesta de la API.
- En el registro el DNI hay que tratarlo como un numero para enviarlo a la API.